### PR TITLE
feat: make api-server url configurable

### DIFF
--- a/cmd/balcheck-cli/main.go
+++ b/cmd/balcheck-cli/main.go
@@ -13,7 +13,10 @@ import (
 	"github.com/emerishq/balcheck/pkg/emeris"
 )
 
-var fullAddr = flag.String("addr", "", "address to check (e.g. cosmos1qymla9gh8z2cmrylt008hkre0gry6h92sxgazg)")
+var (
+	fullAddr = flag.String("addr", "", "address to check (e.g. cosmos1qymla9gh8z2cmrylt008hkre0gry6h92sxgazg)")
+	apiUrl   = flag.String("apiurl", "https://api.emeris.com/v1", "emeris api url (default https://api.emeris.com/v1)")
+)
 
 func main() {
 	flag.Parse()
@@ -41,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	emerisClient := emeris.NewClient()
+	emerisClient := emeris.NewClient(*apiUrl)
 	chains, err := emerisClient.Chains(ctx)
 	if err != nil {
 		panic(err)

--- a/cmd/balcheck/main.go
+++ b/cmd/balcheck/main.go
@@ -26,6 +26,7 @@ func main() {
 		"SentryEnvironment":      "notset",
 		"SentrySampleRate":       "1.0",
 		"SentryTracesSampleRate": "0.3",
+		"EmerisApiURL":           "http://api-server:8000/",
 	})
 
 	if err := sentry.Init(sentry.ClientOptions{
@@ -57,7 +58,7 @@ func main() {
 	)
 	golog.SetLogger(logger)
 
-	emerisClient := emeris.NewClient()
+	emerisClient := emeris.NewClient(c.EmerisApiURL)
 
 	fmt.Printf("Starting server on %s\n", c.ListenAddr)
 
@@ -77,6 +78,7 @@ type Config struct {
 	SentryEnvironment      string
 	SentrySampleRate       float64
 	SentryTracesSampleRate float64
+	EmerisApiURL           string
 }
 
 func (c *Config) Validate() error {

--- a/pkg/emeris/client.go
+++ b/pkg/emeris/client.go
@@ -16,15 +16,18 @@ type Client struct {
 	HTTP    *httpx.Client
 }
 
-func NewClient() *Client {
+func NewClient(baseURL string) *Client {
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
 	return &Client{
-		BaseURL: "https://api.emeris.com",
+		BaseURL: baseURL,
 		HTTP:    httpx.NewClient(),
 	}
 }
 
 func (c *Client) BalancesURL(addr string) string {
-	return fmt.Sprintf("%s/v1/account/%s/balance", c.BaseURL, addr)
+	return fmt.Sprintf("%saccount/%s/balance", c.BaseURL, addr)
 }
 
 func (c *Client) Balances(ctx context.Context, addr string) (checker.Balances, error) {
@@ -69,7 +72,7 @@ type BalancesResponse struct {
 }
 
 func (c *Client) Chains(ctx context.Context) ([]checker.Chain, error) {
-	url := c.BaseURL + "/v1/chains"
+	url := c.BaseURL + "v1/chains"
 
 	golog.With(
 		golog.String("url", url),
@@ -132,7 +135,7 @@ type ChainsResponse struct {
 }
 
 func (c *Client) StakingBalancesURL(addr string) string {
-	return fmt.Sprintf("%s/v1/account/%s/stakingbalances", c.BaseURL, addr)
+	return fmt.Sprintf("%sv1/account/%s/stakingbalances", c.BaseURL, addr)
 }
 
 func (c *Client) StakingBalances(ctx context.Context, addr string) (checker.Balances, error) {
@@ -163,7 +166,7 @@ type StakingBalancesResponse struct {
 }
 
 func (c *Client) UnstakingBalancesURL(addr string) string {
-	return fmt.Sprintf("%s/v1/account/%s/unbondingdelegations", c.BaseURL, addr)
+	return fmt.Sprintf("%sv1/account/%s/unbondingdelegations", c.BaseURL, addr)
 }
 
 func (c *Client) UnstakingBalances(ctx context.Context, addr string) (checker.Balances, error) {


### PR DESCRIPTION
This PR makes the emeris api-url configurable. By default the api-server of the current cluster will be used (so that the staging balcheck will use the staging api-server, ...).